### PR TITLE
Fix recalculation of contentInset when moving to window

### DIFF
--- a/Pod/Classes/GSKStretchyHeaderView.m
+++ b/Pod/Classes/GSKStretchyHeaderView.m
@@ -112,12 +112,6 @@ static void *GSKStretchyHeaderViewObserverContext = &GSKStretchyHeaderViewObserv
         [self stopObservingScrollView];
         self.scrollView = nil;
     }
-
-    if ([self.superview isKindOfClass:[UIScrollView class]]) {
-        self.scrollView = (UIScrollView *)self.superview;
-        [self observeScrollView];
-        [self setupScrollViewInsets];
-    }
 }
 
 #pragma mark - Private properties and methods


### PR DESCRIPTION
Apparently when moving to a new window, the contentInset for the scrollView is being recalculated.
From my point of view there is no need to recalculate it after the view was added if no new value changed.  If we keep these lines, if some other view (i.e. UIRefreshControl)  is operating with contentInset, the values are messed and wrongly calculated
