### PR TITLE
Fix recalculation of contentInset when moving to window

### DIFF
--- a/Pod/Classes/GSKStretchyHeaderView.m
+++ b/Pod/Classes/GSKStretchyHeaderView.m
@@ -99,9 +99,6 @@ static void *GSKStretchyHeaderViewObserverContext = &GSKStretchyHeaderViewObserv
     [super willMoveToWindow:newWindow];
     if (!newWindow) {
         [self stopObservingScrollView];
-    } else {
-        [self observeScrollView];
-        [self setupScrollViewInsets];
     }
 }
 

--- a/Pod/Classes/GSKStretchyHeaderView.m
+++ b/Pod/Classes/GSKStretchyHeaderView.m
@@ -99,6 +99,8 @@ static void *GSKStretchyHeaderViewObserverContext = &GSKStretchyHeaderViewObserv
     [super willMoveToWindow:newWindow];
     if (!newWindow) {
         [self stopObservingScrollView];
+    } else {
+        [self observeScrollView];
     }
 }
 


### PR DESCRIPTION
Apparently when moving to a new window, the contentInset for the scrollView is being recalculated.
From my point of view there is no need to recalculate it after the view was added if no new value changed. If we keep these lines, if some other view (i.e. UIRefreshControl) is operating with contentInset, the values are messed and wrongly calculated
