### PR TITLE
Make stretchy header view stay on top

### DIFF
--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		C066207A1C87311000F1AEF5 /* GSKAirbnbExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C06620791C87311000F1AEF5 /* GSKAirbnbExampleViewController.m */; };
 		C086E0031C846309002A54C1 /* GSKExampleNavigationBarViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C086E0021C846309002A54C1 /* GSKExampleNavigationBarViewController.m */; };
 		C086E00A1C846C5E002A54C1 /* GSKExampleBaseTableViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C086E0091C846C5E002A54C1 /* GSKExampleBaseTableViewController.m */; };
+		C090247B1C901F2300264C0D /* GSKVisibleSectionHeadersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = C090247A1C901F2300264C0D /* GSKVisibleSectionHeadersViewController.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,6 +125,8 @@
 		C086E0021C846309002A54C1 /* GSKExampleNavigationBarViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GSKExampleNavigationBarViewController.m; sourceTree = "<group>"; };
 		C086E0081C846C5E002A54C1 /* GSKExampleBaseTableViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSKExampleBaseTableViewController.h; sourceTree = "<group>"; };
 		C086E0091C846C5E002A54C1 /* GSKExampleBaseTableViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GSKExampleBaseTableViewController.m; sourceTree = "<group>"; };
+		C09024791C901F2300264C0D /* GSKVisibleSectionHeadersViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GSKVisibleSectionHeadersViewController.h; sourceTree = "<group>"; };
+		C090247A1C901F2300264C0D /* GSKVisibleSectionHeadersViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GSKVisibleSectionHeadersViewController.m; sourceTree = "<group>"; };
 		D1AD58004EA1E848A413AC19 /* Pods-Tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.release.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.release.xcconfig"; sourceTree = "<group>"; };
 		E1102AD940C5DCD6E40E9838 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Pods/Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		EF8E73D1214505001DFDBCBC /* Pods-Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Tests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Tests/Pods-Tests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -272,6 +275,8 @@
 				C086E0021C846309002A54C1 /* GSKExampleNavigationBarViewController.m */,
 				C06620781C87311000F1AEF5 /* GSKAirbnbExampleViewController.h */,
 				C06620791C87311000F1AEF5 /* GSKAirbnbExampleViewController.m */,
+				C09024791C901F2300264C0D /* GSKVisibleSectionHeadersViewController.h */,
+				C090247A1C901F2300264C0D /* GSKVisibleSectionHeadersViewController.m */,
 			);
 			name = "View Controllers";
 			sourceTree = "<group>";
@@ -552,6 +557,7 @@
 				C03FC4F41C820C9C0015FAAA /* GSKNibStretchyHeaderView.m in Sources */,
 				C066207A1C87311000F1AEF5 /* GSKAirbnbExampleViewController.m in Sources */,
 				C03FC5031C8348150015FAAA /* GSKExampleTabsViewController.m in Sources */,
+				C090247B1C901F2300264C0D /* GSKVisibleSectionHeadersViewController.m in Sources */,
 				6003F59E195388D20070C39A /* GSKAppDelegate.m in Sources */,
 				C0116C2D1C81A4E7003EDACA /* GSKTestStretchyHeaderView.m in Sources */,
 				C0276CCC1C86F46700AFDA42 /* GSKAirbnbStretchyHeaderView.m in Sources */,

--- a/Example/GSKStretchyHeaderView/GSKExampleBaseTableViewController.h
+++ b/Example/GSKStretchyHeaderView/GSKExampleBaseTableViewController.h
@@ -1,18 +1,14 @@
 @import UIKit;
 @import GSKStretchyHeaderView;
 
-#import "GSKExampleData.h"
 #import "GSKExampleDataSource.h"
 
 @interface GSKExampleBaseTableViewController : UITableViewController
 
-@property (nonatomic, readonly) GSKExampleData *data;
 @property (nonatomic, readonly) GSKStretchyHeaderView *stretchyHeaderView;
 @property (nonatomic, readonly) GSKExampleDataSource *dataSource;
 
-- (instancetype)initWithCoder:(NSCoder *)aDecoder NS_UNAVAILABLE;
-- (instancetype)initWithStyle:(UITableViewStyle)style NS_UNAVAILABLE;
-- (instancetype)initWithData:(GSKExampleData *)data;
+- (GSKExampleDataSource *)loadDataSource;
 - (GSKStretchyHeaderView *)loadStretchyHeaderView;
 
 @end

--- a/Example/GSKStretchyHeaderView/GSKExampleBaseTableViewController.m
+++ b/Example/GSKStretchyHeaderView/GSKExampleBaseTableViewController.m
@@ -9,20 +9,12 @@ static const NSUInteger kNumberOfRows = 100;
 
 @implementation GSKExampleBaseTableViewController
 
-- (instancetype)initWithData:(GSKExampleData *)data {
-    self = [super initWithStyle:UITableViewStylePlain];
-    if (self) {
-        _data = data;
-    }
-    return self;
-}
-
 - (void)viewDidLoad {
     [super viewDidLoad];
     _stretchyHeaderView = [self loadStretchyHeaderView];
     [self.tableView addSubview:self.stretchyHeaderView];
 
-    _dataSource = [[GSKExampleDataSource alloc] initWithNumberOfRows:kNumberOfRows];
+    _dataSource = [self loadDataSource];
     [self.dataSource registerForTableView:self.tableView];
 }
 
@@ -30,6 +22,10 @@ static const NSUInteger kNumberOfRows = 100;
 - (GSKStretchyHeaderView *)loadStretchyHeaderView {
     NSAssert(NO, @"please override %@", NSStringFromSelector(_cmd));
     return nil;
+}
+
+- (GSKExampleDataSource *)loadDataSource {
+    return [[GSKExampleDataSource alloc] initWithNumberOfRows:kNumberOfRows];
 }
 
 @end

--- a/Example/GSKStretchyHeaderView/GSKExampleListViewController.m
+++ b/Example/GSKStretchyHeaderView/GSKExampleListViewController.m
@@ -11,6 +11,7 @@
 #import "GSKExampleTabsViewController.h"
 #import "GSKExampleNavigationBarViewController.h"
 #import "GSKAirbnbExampleViewController.h"
+#import "GSKVisibleSectionHeadersViewController.h"
 
 @interface GSKExampleListViewController () <GSKExampleDataCellDelegate>
 @property (nonatomic) NSArray *exampleDatas;
@@ -43,7 +44,10 @@
     GSKExampleData *navBar = [GSKExampleData dataWithTitle:@"Under navigation bar"
                                        viewControllerClass:[GSKExampleNavigationBarViewController class]];
 
-    self.exampleDatas = @[airbnb, spoty, firstExample, nib, tabs, navBar];
+    GSKExampleData *visibleHeaders = [GSKExampleData dataWithTitle:@"Visible section headers"
+                                               viewControllerClass:[GSKVisibleSectionHeadersViewController class]];
+
+    self.exampleDatas = @[airbnb, spoty, firstExample, nib, tabs, navBar, visibleHeaders];
 }
 
 - (void)viewWillAppear:(BOOL)animated {

--- a/Example/GSKStretchyHeaderView/GSKExampleTableViewController.h
+++ b/Example/GSKStretchyHeaderView/GSKExampleTableViewController.h
@@ -1,5 +1,10 @@
 #import "GSKExampleBaseTableViewController.h"
+#import "GSKExampleData.h"
 
 @interface GSKExampleTableViewController : GSKExampleBaseTableViewController
+
+@property (nonatomic, readonly) GSKExampleData *data;
+
+- (instancetype)initWithData:(GSKExampleData *)data;
 
 @end

--- a/Example/GSKStretchyHeaderView/GSKExampleTableViewController.m
+++ b/Example/GSKStretchyHeaderView/GSKExampleTableViewController.m
@@ -3,6 +3,14 @@
 
 @implementation GSKExampleTableViewController
 
+- (instancetype)initWithData:(GSKExampleData *)data {
+    self = [super initWithStyle:UITableViewStylePlain];
+    if (self) {
+        _data = data;
+    }
+    return self;
+}
+
 - (void)viewWillAppear:(BOOL)animated {
     [super viewWillAppear:animated];
     if (!self.data.navigationBarVisible) {

--- a/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.h
+++ b/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.h
@@ -1,0 +1,5 @@
+#import "GSKExampleBaseTableViewController.h"
+
+@interface GSKVisibleSectionHeadersViewController : GSKExampleBaseTableViewController
+
+@end

--- a/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.m
+++ b/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.m
@@ -1,0 +1,63 @@
+#import "GSKVisibleSectionHeadersViewController.h"
+#import "GSKSpotyLikeHeaderView.h"
+#import "UINavigationController+Transparency.h"
+
+@interface GSKVisibleSectionHeadersDataSource : GSKExampleDataSource
+@property (nonatomic) CGFloat stretchyHeaderViewMaximumContentHeight;
+@property (nonatomic) CGFloat stretchyHeaderViewMinimumContentHeight;
+@end
+
+@implementation GSKVisibleSectionHeadersViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.automaticallyAdjustsScrollViewInsets = NO;
+}
+
+- (void)viewWillAppear:(BOOL)animated {
+    [super viewWillAppear:animated];
+    [self.navigationController gsk_setNavigationBarTransparent:YES animated:NO];
+    self.navigationController.navigationBar.barStyle = UIBarStyleBlack;
+    self.navigationController.navigationBar.tintColor = [UIColor whiteColor];
+}
+
+- (GSKStretchyHeaderView *)loadStretchyHeaderView {
+    return [[GSKSpotyLikeHeaderView alloc] initWithFrame:CGRectMake(0, 0, self.view.width, 280)];
+}
+
+- (GSKExampleDataSource *)loadDataSource {
+    GSKVisibleSectionHeadersDataSource *dataSource = [[GSKVisibleSectionHeadersDataSource alloc] init];
+    dataSource.stretchyHeaderViewMaximumContentHeight = self.stretchyHeaderView.maximumContentHeight;
+    dataSource.stretchyHeaderViewMinimumContentHeight = self.stretchyHeaderView.minimumContentHeight;
+    return dataSource;
+}
+
+@end
+
+@implementation GSKVisibleSectionHeadersDataSource
+
+- (instancetype)init {
+    return [self initWithNumberOfRows:10];
+}
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 10;
+}
+
+- (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
+    return [NSString stringWithFormat:@"Section #%@", @(section)];
+}
+
+- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
+    UIEdgeInsets scrollViewContentInset = scrollView.contentInset;
+    if (scrollView.contentOffset.y > -self.stretchyHeaderViewMinimumContentHeight) {
+        scrollViewContentInset.top = self.stretchyHeaderViewMinimumContentHeight;
+    } else if (scrollView.contentOffset.y < -self.stretchyHeaderViewMaximumContentHeight) {
+        scrollViewContentInset.top = self.stretchyHeaderViewMaximumContentHeight;
+    } else {
+        scrollViewContentInset.top = -scrollView.contentOffset.y;
+    }
+    scrollView.contentInset = scrollViewContentInset;
+}
+
+@end

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -8,7 +8,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.0.7)
   - FBSnapshotTestCase/SwiftSupport (2.0.7):
     - FBSnapshotTestCase/Core
-  - GSKStretchyHeaderView (0.8.0)
+  - GSKStretchyHeaderView (0.8.2)
   - Masonry (0.6.4)
   - Specta (1.0.5)
 
@@ -28,7 +28,7 @@ SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Expecta+Snapshots: 29b38dd695bc72a0ed2bea833937d78df41943ba
   FBSnapshotTestCase: 7e85180d0d141a0cf472352edda7e80d7eaeb547
-  GSKStretchyHeaderView: d81c41a328b18f42526959181343867dfe5c7146
+  GSKStretchyHeaderView: 14d0aa8dcc89fa29330ba30d7ff0d98376b46748
   Masonry: 281802d04d787ea2973179ee8bcb50500579ede2
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 

--- a/Example/Pods/Local Podspecs/GSKStretchyHeaderView.podspec.json
+++ b/Example/Pods/Local Podspecs/GSKStretchyHeaderView.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "GSKStretchyHeaderView",
-  "version": "0.8.0",
+  "version": "0.8.2",
   "summary": "A generic, easy to use stretchy header view for UITableView and UICollectionView",
   "description": "GSKStretchyHeaderView allows you to add a stretchy header view (like Twitter's or Spotify's) to any existing UITableView and UICollectionView. There is no need inherit from custom view controllers, just create your custom header view and add it to your UITableView or UICollectionView. Creating a custom stretchy header view is as easy as inheriting from the base class or using Interface Builder.",
   "homepage": "https://github.com/gskbyte/GSKStretchyHeaderView",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/gskbyte/GSKStretchyHeaderView.git",
-    "tag": "0.8.0"
+    "tag": "0.8.2"
   },
   "social_media_url": "https://twitter.com/gskbyte",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -8,7 +8,7 @@ PODS:
   - FBSnapshotTestCase/Core (2.0.7)
   - FBSnapshotTestCase/SwiftSupport (2.0.7):
     - FBSnapshotTestCase/Core
-  - GSKStretchyHeaderView (0.8.0)
+  - GSKStretchyHeaderView (0.8.2)
   - Masonry (0.6.4)
   - Specta (1.0.5)
 
@@ -28,7 +28,7 @@ SPEC CHECKSUMS:
   Expecta: e1c022fcd33910b6be89c291d2775b3fe27a89fe
   Expecta+Snapshots: 29b38dd695bc72a0ed2bea833937d78df41943ba
   FBSnapshotTestCase: 7e85180d0d141a0cf472352edda7e80d7eaeb547
-  GSKStretchyHeaderView: d81c41a328b18f42526959181343867dfe5c7146
+  GSKStretchyHeaderView: 14d0aa8dcc89fa29330ba30d7ff0d98376b46748
   Masonry: 281802d04d787ea2973179ee8bcb50500579ede2
   Specta: ac94d110b865115fe60ff2c6d7281053c6f8e8a2
 

--- a/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/GSKStretchyHeaderView.xcscheme
+++ b/Example/Pods/Pods.xcodeproj/xcshareddata/xcschemes/GSKStretchyHeaderView.xcscheme
@@ -14,7 +14,7 @@
             buildForArchiving = "YES">
             <BuildableReference
                BuildableIdentifier = 'primary'
-               BlueprintIdentifier = 'A7AE8CE26A9DFC7179E308E7'
+               BlueprintIdentifier = '78A582C0769C3F50E54F708F'
                BlueprintName = 'GSKStretchyHeaderView'
                ReferencedContainer = 'container:Pods.xcodeproj'
                BuildableName = 'GSKStretchyHeaderView.framework'>

--- a/Example/Pods/Target Support Files/GSKStretchyHeaderView/Info.plist
+++ b/Example/Pods/Target Support Files/GSKStretchyHeaderView/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.8.0</string>
+  <string>0.8.2</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/GSKStretchyHeaderView.podspec
+++ b/GSKStretchyHeaderView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "GSKStretchyHeaderView"
-  s.version          = "0.8.1"
+  s.version          = "0.8.2"
   s.summary          = "A generic, easy to use stretchy header view for UITableView and UICollectionView"
   s.description      = <<-DESC
                        GSKStretchyHeaderView allows you to add a stretchy header view (like Twitter's or Spotify's) to any existing UITableView and UICollectionView. There is no need inherit from custom view controllers, just create your custom header view and add it to your UITableView or UICollectionView. Creating a custom stretchy header view is as easy as inheriting from the base class or using Interface Builder.

--- a/Pod/Classes/GSKStretchyHeaderView.m
+++ b/Pod/Classes/GSKStretchyHeaderView.m
@@ -127,6 +127,11 @@ static void *GSKStretchyHeaderViewObserverContext = &GSKStretchyHeaderViewObserv
                           forKeyPath:@"contentOffset"
                              options:NSKeyValueObservingOptionNew
                              context:GSKStretchyHeaderViewObserverContext];
+        [self.scrollView.layer addObserver:self
+                           forKeyPath:@"sublayers"
+                              options:NSKeyValueObservingOptionNew
+                              context:GSKStretchyHeaderViewObserverContext];
+
         self.observingScrollView = YES;
     }
 }
@@ -136,6 +141,9 @@ static void *GSKStretchyHeaderViewObserverContext = &GSKStretchyHeaderViewObserv
         [self.scrollView removeObserver:self
                              forKeyPath:@"contentOffset"
                                 context:GSKStretchyHeaderViewObserverContext];
+        [self.scrollView.layer removeObserver:self
+                                   forKeyPath:@"sublayers"
+                                      context:GSKStretchyHeaderViewObserverContext];
         self.observingScrollView = NO;
     }
 }
@@ -155,6 +163,9 @@ static void *GSKStretchyHeaderViewObserverContext = &GSKStretchyHeaderViewObserv
         NSValue *newValue = change[NSKeyValueChangeNewKey];
         CGPoint contentOffset = newValue.CGPointValue;
         [self updateOriginForContentOffset:contentOffset];
+    } else if (object == self.scrollView.layer &&
+               [keyPath isEqualToString:@"sublayers"]) {
+        [self.scrollView bringSubviewToFront:self];
     }
 }
 


### PR DESCRIPTION
To basically avoid section header and footer views to overlap it. This PR also adds an example for it and increases the version number, as well as some smaller cleanups.

Related issue: https://github.com/gskbyte/GSKStretchyHeaderView/issues/5
