### PR TITLE
Fix issue #22: header crashes when being manually removed from the scroll view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 1.0.0 Soon!!!
 
+# 0.12.1
+
+- Fix crash when removing from scroll view
+
 # 0.12.0
 
 - Remove dependency on `KVOController``

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GSKStretchyHeaderView (0.12.0)
+  - GSKStretchyHeaderView (0.12.1)
   - Masonry (1.0.1)
 
 DEPENDENCIES:
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GSKStretchyHeaderView: 25554059df35b7b01b37373eba1e1e57582c45a2
+  GSKStretchyHeaderView: f6c780ee623d0795ca4d45ad80b93ba689545114
   Masonry: a1a931a0d08870ed8ae415a2ea5ea68ebcac77df
 
 PODFILE CHECKSUM: d2d76392ebaf9a2519a5ffd1b02145c1bf8e7420

--- a/Example/Pods/Local Podspecs/GSKStretchyHeaderView.podspec.json
+++ b/Example/Pods/Local Podspecs/GSKStretchyHeaderView.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "GSKStretchyHeaderView",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "summary": "A generic, easy to use stretchy header view for UITableView and UICollectionView",
   "description": "GSKStretchyHeaderView allows you to add a stretchy header view (like Twitter's or Spotify's) to any existing UITableView and UICollectionView. There is no need inherit from custom view controllers, just create your custom header view and add it to your UITableView or UICollectionView. Creating a custom stretchy header view is as easy as inheriting from the base class or using Interface Builder.",
   "homepage": "https://github.com/gskbyte/GSKStretchyHeaderView",
@@ -14,7 +14,7 @@
   },
   "source": {
     "git": "https://github.com/gskbyte/GSKStretchyHeaderView.git",
-    "tag": "0.12.0"
+    "tag": "0.12.1"
   },
   "social_media_url": "https://twitter.com/gskbyte",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - GSKStretchyHeaderView (0.12.0)
+  - GSKStretchyHeaderView (0.12.1)
   - Masonry (1.0.1)
 
 DEPENDENCIES:
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  GSKStretchyHeaderView: 25554059df35b7b01b37373eba1e1e57582c45a2
+  GSKStretchyHeaderView: f6c780ee623d0795ca4d45ad80b93ba689545114
   Masonry: a1a931a0d08870ed8ae415a2ea5ea68ebcac77df
 
 PODFILE CHECKSUM: d2d76392ebaf9a2519a5ffd1b02145c1bf8e7420

--- a/Example/Pods/Target Support Files/GSKStretchyHeaderView/Info.plist
+++ b/Example/Pods/Target Support Files/GSKStretchyHeaderView/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.12.0</string>
+  <string>0.12.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/GSKStretchyHeaderView.podspec
+++ b/GSKStretchyHeaderView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "GSKStretchyHeaderView"
-  s.version          = "0.12.0"
+  s.version          = "0.12.1"
   s.summary          = "A generic, easy to use stretchy header view for UITableView and UICollectionView"
   s.description      = <<-DESC
                        GSKStretchyHeaderView allows you to add a stretchy header view (like Twitter's or Spotify's) to any existing UITableView and UICollectionView. There is no need inherit from custom view controllers, just create your custom header view and add it to your UITableView or UICollectionView. Creating a custom stretchy header view is as easy as inheriting from the base class or using Interface Builder.

--- a/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.m
+++ b/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.m
@@ -169,6 +169,10 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
 }
 
 - (void)stopObservingScrollView {
+    if (!self.observingScrollView) {
+        return;
+    }
+    
     [self.scrollView removeObserver:self forKeyPath:NSStringFromSelector(@selector(contentOffset))];
     [self.scrollView.layer removeObserver:self forKeyPath:NSStringFromSelector(@selector(sublayers))];
     

--- a/GSKStretchyHeaderView/GSKStretchyHeaderView/Info.plist
+++ b/GSKStretchyHeaderView/GSKStretchyHeaderView/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12</string>
+	<string>0.12.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/GSKStretchyHeaderView/GSKStretchyHeaderViewTests/GSKStretchyHeaderViewTests.m
+++ b/GSKStretchyHeaderView/GSKStretchyHeaderViewTests/GSKStretchyHeaderViewTests.m
@@ -183,6 +183,17 @@ static const CGFloat kInitialHeaderViewHeight = 280;
     XCTAssertEqualFrame(headerView.contentView.frame, CGRectMake(0, 0, 320, 220));
 }
 
+- (void)testShouldNotCrashAfterRemoval {
+    GSKStretchyHeaderView *headerView = [self headerView];
+    headerView.minimumContentHeight = 120;
+    headerView.expansionMode = GSKStretchyHeaderViewExpansionModeImmediate;
+    headerView.contentExpands = NO;
+    [self.scrollView addSubview:headerView];
+    
+    [headerView removeFromSuperview];
+    XCTAssertNil(headerView.superview);
+}
+
 - (void)testLoadFromXib {
     NSArray* nibViews = [[NSBundle bundleForClass:self.class] loadNibNamed:@"GSKTestHeaderView"
                                                       owner:self


### PR DESCRIPTION
Includes a test to prove it
