### PR TITLE
Add possibility to disable the scrollView contentInset management

### DIFF
--- a/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.m
+++ b/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.m
@@ -4,16 +4,21 @@
 #import "UIView+GSKLayoutHelper.h"
 
 @interface GSKVisibleSectionHeadersDataSource : GSKExampleDataSource
-@property (nonatomic) CGFloat stretchyHeaderViewMaximumContentHeight;
-@property (nonatomic) CGFloat stretchyHeaderViewMinimumContentHeight;
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView;
+
 @end
 
 @implementation GSKVisibleSectionHeadersViewController
 
 - (void)viewDidLoad {
     [super viewDidLoad];
-    self.automaticallyAdjustsScrollViewInsets = NO;
+    
+    // by setting contentInset.top, we set where the section headers will be fixed
+    self.tableView.contentInset = UIEdgeInsetsMake(self.stretchyHeaderView.minimumContentHeight, 0, 0, 0);
+    // we add an empty header view at the top of the table view to increase the initial offset before the first section header
+    self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0,
+                                                                              0,
+                                                                              self.tableView.width,
+                                                                              self.stretchyHeaderView.maximumContentHeight - self.stretchyHeaderView.minimumContentHeight)];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -24,19 +29,16 @@
 }
 
 - (GSKStretchyHeaderView *)loadStretchyHeaderView {
-    return [[GSKSpotyLikeHeaderView alloc] initWithFrame:CGRectMake(0, 0, self.view.width, 280)];
+    GSKSpotyLikeHeaderView *headerView = [[GSKSpotyLikeHeaderView alloc] initWithFrame:CGRectMake(0, 0, self.view.width, 280)];
+    
+    // we have to set this flag before we add the header to the table view, otherwise it will change its insets immediately
+    headerView.manageScrollViewInsets = NO;
+    
+    return headerView;
 }
 
 - (GSKExampleDataSource *)loadDataSource {
-    GSKVisibleSectionHeadersDataSource *dataSource = [[GSKVisibleSectionHeadersDataSource alloc] init];
-    dataSource.stretchyHeaderViewMaximumContentHeight = self.stretchyHeaderView.maximumContentHeight;
-    dataSource.stretchyHeaderViewMinimumContentHeight = self.stretchyHeaderView.minimumContentHeight;
-    return dataSource;
-}
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    GSKVisibleSectionHeadersDataSource *dataSource = (GSKVisibleSectionHeadersDataSource *) self.dataSource;
-    [dataSource scrollViewDidScroll:scrollView];
+    return [[GSKVisibleSectionHeadersDataSource alloc] init];
 }
 
 @end
@@ -44,7 +46,7 @@
 @implementation GSKVisibleSectionHeadersDataSource
 
 - (instancetype)init {
-    return [self initWithNumberOfRows:10];
+    return [self initWithNumberOfRows:7];
 }
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
@@ -53,18 +55,6 @@
 
 - (NSString *)tableView:(UITableView *)tableView titleForHeaderInSection:(NSInteger)section {
     return [NSString stringWithFormat:@"Section #%@", @(section)];
-}
-
-- (void)scrollViewDidScroll:(UIScrollView *)scrollView {
-    UIEdgeInsets scrollViewContentInset = scrollView.contentInset;
-    if (scrollView.contentOffset.y > -self.stretchyHeaderViewMinimumContentHeight) {
-        scrollViewContentInset.top = self.stretchyHeaderViewMinimumContentHeight;
-    } else if (scrollView.contentOffset.y < -self.stretchyHeaderViewMaximumContentHeight) {
-        scrollViewContentInset.top = self.stretchyHeaderViewMaximumContentHeight;
-    } else {
-        scrollViewContentInset.top = -scrollView.contentOffset.y;
-    }
-    scrollView.contentInset = scrollViewContentInset;
 }
 
 @end

--- a/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.m
+++ b/Example/GSKStretchyHeaderView/GSKVisibleSectionHeadersViewController.m
@@ -15,6 +15,7 @@
     // by setting contentInset.top, we set where the section headers will be fixed
     self.tableView.contentInset = UIEdgeInsetsMake(self.stretchyHeaderView.minimumContentHeight, 0, 0, 0);
     // we add an empty header view at the top of the table view to increase the initial offset before the first section header
+    // otherwise the header view would cover the first cells
     self.tableView.tableHeaderView = [[UIView alloc] initWithFrame:CGRectMake(0,
                                                                               0,
                                                                               self.tableView.width,

--- a/Example/GSKStretchyHeaderView/HelperMacros.h
+++ b/Example/GSKStretchyHeaderView/HelperMacros.h
@@ -10,6 +10,7 @@
 #define HelperMacros_h
 
 #define XCTAssertEqualFrame(frame0, frame1) XCTAssertTrue(CGRectEqualToRect(frame0, frame1))
+#define XCTAssertEqualInsets(inset0, inset1) XCTAssertTrue(inset0.top == inset1.top && inset0.left == inset1.left && inset0.right == inset1.right && inset0.bottom == inset1.bottom)
 #define XCTAssertEqualPoint(p0, p1) XCTAssertTrue(CGPointEqualToPoint(p0, p1))
 #define XCTAssertEqualSize(s0, s1) XCTAssertTrue(CGSizeEqualToSize(s0, s1))
 #define XCTAssertInRange(value, min, max) XCTAssertGreaterThan(value, min); XCTAssertLessThan(value, max)

--- a/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.h
+++ b/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.h
@@ -87,7 +87,8 @@ typedef NS_ENUM(NSUInteger, GSKStretchyHeaderViewExpansionMode) {
 @property(nonatomic) IBInspectable UIEdgeInsets contentInset;
 
 /**
- *  Specifies wether the contentView sticks to the top or the bottom of the headerView. Default value is GSKStretchyHeaderContentViewAnchorTop.
+ *  Specifies wether the contentView sticks to the top or the bottom of the headerView. 
+ *  Default value is GSKStretchyHeaderContentViewAnchorTop.
  *  This has effect only if contentShrinks and/or contentExpands are set to NO.
  */
 #if TARGET_INTERFACE_BUILDER
@@ -95,6 +96,14 @@ typedef NS_ENUM(NSUInteger, GSKStretchyHeaderViewExpansionMode) {
 #else
 @property(nonatomic) GSKStretchyHeaderViewContentAnchor contentAnchor;
 #endif
+
+/**
+ *  Indicates if the header view changes the scrollView insets automatically. You usually want to
+ *  enable this property, unless you have a table view with sticky visible section headers.
+ *  Have a look at this issue for more information: https://github.com/gskbyte/GSKStretchyHeaderView/issues/17
+ *  Default value is YES.
+ */
+@property(nonatomic) BOOL manageScrollViewInsets;
 
 /**
  *  Specifies wether the contentView height shrinks when scrolling up. Default is YES.

--- a/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.m
+++ b/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.m
@@ -67,6 +67,7 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
     self.contentAnchor = GSKStretchyHeaderViewContentAnchorTop;
     self.contentExpands = YES;
     self.contentShrinks = YES;
+    self.manageScrollViewInsets = YES;
 }
 
 - (void)setupContentView {
@@ -91,7 +92,7 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
     }
 
     _maximumContentHeight = maximumContentHeight;
-    [self setupScrollViewInsets];
+    [self setupScrollViewInsetsIfNeeded];
     [self.scrollView gsk_layoutStretchyHeaderView:self
                                     contentOffset:self.scrollView.contentOffset
                             previousContentOffset:self.scrollView.contentOffset];
@@ -99,7 +100,7 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
 
 - (void)setContentInset:(UIEdgeInsets)contentInset {
     _contentInset = contentInset;
-    [self setupScrollViewInsets];
+    [self setupScrollViewInsetsIfNeeded];
 }
 
 #pragma mark - Public methods
@@ -150,7 +151,7 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
     self.scrollView = (UIScrollView *)self.superview;
     [self observeScrollViewIfPossible];
     
-    [self setupScrollViewInsets];
+    [self setupScrollViewInsetsIfNeeded];
 }
 
 - (void)observeScrollViewIfPossible {
@@ -218,10 +219,12 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
     return self.minimumContentHeight + self.verticalInset;
 }
 
-- (void)setupScrollViewInsets {
-    UIEdgeInsets scrollViewContentInset = self.scrollView.contentInset;
-    scrollViewContentInset.top = self.maximumContentHeight + self.contentInset.top + self.contentInset.bottom;
-    self.scrollView.contentInset = scrollViewContentInset;
+- (void)setupScrollViewInsetsIfNeeded {
+    if (self.scrollView && self.manageScrollViewInsets) {
+        UIEdgeInsets scrollViewContentInset = self.scrollView.contentInset;
+        scrollViewContentInset.top = self.maximumContentHeight + self.contentInset.top + self.contentInset.bottom;
+        self.scrollView.contentInset = scrollViewContentInset;
+    }
 }
 
 - (void)setNeedsLayoutContentView {

--- a/GSKStretchyHeaderView/Classes/Private/UIScrollView+GSKStretchyHeaderView.m
+++ b/GSKStretchyHeaderView/Classes/Private/UIScrollView+GSKStretchyHeaderView.m
@@ -33,14 +33,13 @@
     NSAssert(headerView.superview == self, @"The provided header view must be a subview of %@", self);
     NSUInteger stretchyHeaderViewIndex = [self.subviews indexOfObjectIdenticalTo:headerView];
     NSUInteger stretchyHeaderViewNewIndex = stretchyHeaderViewIndex;
-    for (UIView *subview in self.subviews) {
+    for (NSUInteger i = stretchyHeaderViewIndex + 1; i < self.subviews.count; ++i) {
+        UIView *subview = self.subviews[i];
         if ([subview gsk_shouldBeBelowStretchyHeaderView]) {
-            NSUInteger subviewIndex = [self.subviews indexOfObjectIdenticalTo:subview];
-            if (subviewIndex > stretchyHeaderViewNewIndex) {
-                stretchyHeaderViewNewIndex = subviewIndex;
-            }
+            stretchyHeaderViewNewIndex = i;
         }
     }
+    
     if (stretchyHeaderViewIndex != stretchyHeaderViewNewIndex) {
         [self exchangeSubviewAtIndex:stretchyHeaderViewIndex
                   withSubviewAtIndex:stretchyHeaderViewNewIndex];

--- a/GSKStretchyHeaderView/Classes/Private/UIScrollView+GSKStretchyHeaderView.m
+++ b/GSKStretchyHeaderView/Classes/Private/UIScrollView+GSKStretchyHeaderView.m
@@ -58,6 +58,12 @@
         headerFrame.size.width = CGRectGetWidth(self.bounds);
     }
     
+    if (!headerView.manageScrollViewInsets) {
+        CGFloat offsetAdjustment = headerView.maximumHeight - headerView.minimumHeight;
+        contentOffset.y -= offsetAdjustment;
+        previousContentOffset.y -= offsetAdjustment;
+    }
+    
     CGFloat headerViewHeight = CGRectGetHeight(headerView.bounds);
     switch (headerView.expansionMode) {
         case GSKStretchyHeaderViewExpansionModeTopOnly: {

--- a/GSKStretchyHeaderView/GSKStretchyHeaderViewTests/GSKStretchyHeaderViewTests.m
+++ b/GSKStretchyHeaderView/GSKStretchyHeaderViewTests/GSKStretchyHeaderViewTests.m
@@ -194,6 +194,32 @@ static const CGFloat kInitialHeaderViewHeight = 280;
     XCTAssertNil(headerView.superview);
 }
 
+- (void)testCalculateFrameWhenNotManagingScrollViewInsets {
+    GSKStretchyHeaderView *headerView = [self headerView];
+    headerView.minimumContentHeight = 64;
+    headerView.manageScrollViewInsets = NO;
+    [self.scrollView addSubview:headerView];
+    
+    XCTAssertEqualInsets(UIEdgeInsetsZero, self.scrollView.contentInset);
+    
+    // Force scroll by moving it twice
+    [self.scrollView setContentOffset:CGPointMake(0, 1)
+                             animated:NO];
+    [self.scrollView setContentOffset:CGPointMake(0, -self.scrollView.contentInset.top)
+                             animated:NO];
+    
+    // if we don't set the content inset of the scrollview manually to the minimum content height,
+    // the header view won't reach its maximum height naturally (we have to swipe down)
+    XCTAssertEqualFrame(headerView.frame, CGRectMake(0, 0, self.scrollView.width, headerView.maximumContentHeight - headerView.minimumContentHeight));
+    
+    // but if we set it, then it will be layouted properly
+    self.scrollView.contentInset = UIEdgeInsetsMake(headerView.minimumContentHeight, 0, 0, 0);
+    [self.scrollView setContentOffset:CGPointMake(0, -self.scrollView.contentInset.top)
+                             animated:NO]; // scroll it to the top
+    
+    XCTAssertEqualFrame(headerView.frame, CGRectMake(0, -self.scrollView.contentInset.top, self.scrollView.width, kInitialHeaderViewHeight));
+}
+
 - (void)testLoadFromXib {
     NSArray* nibViews = [[NSBundle bundleForClass:self.class] loadNibNamed:@"GSKTestHeaderView"
                                                       owner:self


### PR DESCRIPTION
This should ease the usage of the header view within table views with sticky headers (issue #17). Also modifies the example for this feature and includes tests.
