### PR TITLE
Fixed crash when removing header from a superview without window

### DIFF
--- a/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.m
+++ b/GSKStretchyHeaderView/Classes/GSKStretchyHeaderView.m
@@ -169,6 +169,13 @@ static const CGFloat kNibDefaultMaximumContentHeight = 240;
     self.observingScrollView = YES;
 }
 
+- (void)removeFromSuperview {
+
+    [self stopObservingScrollView];
+
+    [super removeFromSuperview];
+}
+
 - (void)stopObservingScrollView {
     if (!self.observingScrollView) {
         return;

--- a/GSKStretchyHeaderView/GSKStretchyHeaderViewTests/GSKStretchyHeaderViewTests.m
+++ b/GSKStretchyHeaderView/GSKStretchyHeaderViewTests/GSKStretchyHeaderViewTests.m
@@ -194,6 +194,15 @@ static const CGFloat kInitialHeaderViewHeight = 280;
     XCTAssertNil(headerView.superview);
 }
 
+- (void)testShouldNotCrashAfterRemovalFromSuperviewWithoutWindow {
+    GSKStretchyHeaderView *headerView = [self headerView];
+    UIScrollView *scrollView = [[UIScrollView alloc] initWithFrame:CGRectMake(0, 0, 320, 640)];
+    [scrollView addSubview:headerView];
+
+    [headerView removeFromSuperview];
+    XCTAssertNil(headerView.superview);
+}
+
 - (void)testCalculateFrameWhenNotManagingScrollViewInsets {
     GSKStretchyHeaderView *headerView = [self headerView];
     headerView.minimumContentHeight = 64;


### PR DESCRIPTION
Includes a test which replicates the crash.

I had many of my tests crashing when adding this library because some superviews in my tests are not attached to windows.

This changes allow avoiding the crash with the following code (in the view controller for example):

    deinit {
        self.headerCell.removeFromSuperview()
    }

Instead of my current code which is more implementation aware:

    deinit {
        self.collectionView.removeObserver(self.headerCell, forKeyPath: #keyPath(UICollectionView.contentOffset))
    }

I think it is reasonable to stop observing the scroll view when removing the header from its superview. There may be a better way to fix this, but this is what I could get working.