### PR TITLE
Fix transplant constraints if safe area insets are active

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+# [1.0.3](https://github.com/gskbyte/GSKStretchyHeaderView/releases/tag/1.0.3)
+
+- [Fix layout guides crash on iOS 11](https://github.com/gskbyte/GSKStretchyHeaderView/pull/71)
+
 # [1.0.2](https://github.com/gskbyte/GSKStretchyHeaderView/releases/tag/1.0.2)
 
 - [Fix device rotation issue](https://github.com/gskbyte/GSKStretchyHeaderView/pull/65)
 - [Add Xcode 9 support](https://github.com/gskbyte/GSKStretchyHeaderView/pull/64)
 - [Fix contentInset and view hierarchy issues with iOS 11](https://github.com/gskbyte/GSKStretchyHeaderView/pull/68)
-
 
 Thanks [@julienpouget](https://github.com/julienpouget)!
 

--- a/GSKStretchyHeaderView.podspec
+++ b/GSKStretchyHeaderView.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "GSKStretchyHeaderView"
-  s.version          = "1.0.2"
+  s.version          = "1.0.3"
   s.summary          = "A generic, easy to use stretchy header view for UITableView and UICollectionView"
   s.description      = <<-DESC
                        GSKStretchyHeaderView allows you to add a stretchy header view (like Twitter's or Spotify's) to any existing UITableView and UICollectionView. There is no need inherit from custom view controllers, just create your custom header view and add it to your UITableView or UICollectionView. Creating a custom stretchy header view is as easy as inheriting from the base class or using Interface Builder.

--- a/GSKStretchyHeaderView/Classes/UIView+GSKTransplantSubviews.m
+++ b/GSKStretchyHeaderView/Classes/UIView+GSKTransplantSubviews.m
@@ -29,6 +29,18 @@
 
 @implementation UIView (GSKTransplantSubviews)
 
+- (BOOL)gsk_isSelfOrLayoutGuide:(id)object {
+    // We can't transplant constraints to layout guides like safe area insets (introduced in iOS 11)
+    // So we assume the constraints will be related to the superview
+    // This may become a problem if the safe area insets are not zero, but for header views it's always the case
+    if (object == self) {
+        return true;
+    } else if (@available(iOS 9.0, *)) {
+        return [object isKindOfClass:[UILayoutGuide class]];
+    }
+    return false;
+}
+
 - (void)gsk_transplantSubviewsToView:(UIView *)newSuperview {
     NSArray<UIView *> *oldSubviews = self.subviews;
     NSArray<NSLayoutConstraint *> *oldConstraints = self.constraints;
@@ -47,8 +59,8 @@
 
     [self removeConstraints:oldConstraints];
     [oldConstraints enumerateObjectsUsingBlock:^(NSLayoutConstraint *oldConstraint, NSUInteger index, BOOL *stop) {
-        id firstItem = oldConstraint.firstItem == self ? newSuperview : oldConstraint.firstItem;
-        id secondItem = oldConstraint.secondItem == self ? newSuperview : oldConstraint.secondItem;
+        id firstItem = [self gsk_isSelfOrLayoutGuide:oldConstraint.firstItem] ? newSuperview : oldConstraint.firstItem;
+        id secondItem = [self gsk_isSelfOrLayoutGuide:oldConstraint.secondItem] ? newSuperview : oldConstraint.secondItem;
         NSLayoutConstraint *constraint = [oldConstraint gsk_copyWithFirstItem:firstItem
                                                                    secondItem:secondItem];
         if ([constraint respondsToSelector:@selector(setActive:)]) {


### PR DESCRIPTION
We can't transplant the safe area insets (it's actually crashing on iOS 11), so we just set the constraints to the superview.