### PR TITLE
Only modify a subview's zPosition if it's the default value or will conflict with the new header value

### DIFF
--- a/GSKStretchyHeaderView/Classes/Private/UIScrollView+GSKStretchyHeaderView.m
+++ b/GSKStretchyHeaderView/Classes/Private/UIScrollView+GSKStretchyHeaderView.m
@@ -32,7 +32,7 @@
 - (void)gsk_fixZPositionsForStretchyHeaderView:(GSKStretchyHeaderView *)headerView {
     headerView.layer.zPosition = 1;
     for (UIView *subview in self.subviews) {
-        if (![subview gsk_shouldBeBelowStretchyHeaderView]) {
+        if (![subview gsk_shouldBeBelowStretchyHeaderView] && (subview.layer.zPosition == 0 || subview.layer.zPosition == 1)) {
             subview.layer.zPosition = 2;
         }
     }


### PR DESCRIPTION
This seeks to resolve #81 by only modifying a UIScrollView subview's zPosition if the zPosition is either 0 (meaning the developer has made no zPosition choice or has left it at the default level) or 1 (where the developer has opted to try and get the subview above the default, but the move of the stretchy header view to this zPosition could cause a conflict).

With this change, developers should be able to modify their zPosition of subviews to make them show over or under the stretchy header view however they choose so long as they get out of the range of 0-2.  It seemed a bit overkill to add a protocol to ask the subview if it has a preferred zPosition since most devs will just mess with zPosition numbering until they get something that works.